### PR TITLE
Add safeguard for execute-as group

### DIFF
--- a/wireguard.sh
+++ b/wireguard.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if [ "$(id -g -n)" != 'vyattacfg' ] ; then
+    exec sg vyattacfg -c "/bin/bash $(readlink -f $0) $@"
+fi
 set -e
 
 # The repository from which we fetch new releases.

--- a/wireguard.sh
+++ b/wireguard.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-if [ "$(id -g -n)" != 'vyattacfg' ] ; then
-    exec sg vyattacfg -c "/bin/bash $(readlink -f $0) $@"
-fi
 set -e
+
+if [[ $(id -g -n) != 'vyattacfg' ]]; then
+	exec sg vyattacfg -c "/bin/vbash $(readlink -f "$0") $*"
+fi
 
 # The repository from which we fetch new releases.
 WIREGUARD_REPO=WireGuard/wireguard-vyatta-ubnt


### PR DESCRIPTION
As per the [VyOS docs](https://docs.vyos.io/en/latest/appendix/command-scripting.html#executing-configuration-scripts), running configuration changes as root breaks future configuration changes until the next reboot.
Not only a careless user may run this script as root, it is also the default configuration for the EdgeOS task-scheduler (see `/etc/cron.d/vyatta-crontab`).
The added snippet is taken directly from the VyOS docs linked above to prevent the script from running with the incorrect credentials.